### PR TITLE
add Helps and Infos categories for compiler properties

### DIFF
--- a/make/langtools/tools/propertiesparser/gen/ClassGenerator.java
+++ b/make/langtools/tools/propertiesparser/gen/ClassGenerator.java
@@ -116,6 +116,8 @@ public class ClassGenerator {
         WARN("warn", "Warning", "Warnings"),
         NOTE("note", "Note", "Notes"),
         MISC("misc", "Fragment", "Fragments"),
+        INFO("info", "InfoFragment", "Infos"),
+        HELP("help", "HelpFragment", "Helps"),
         OTHER(null, null, null);
 
         /** The prefix for this factory kind (i.e. 'err'). */

--- a/make/langtools/tools/propertiesparser/resources/templates.properties
+++ b/make/langtools/tools/propertiesparser/resources/templates.properties
@@ -31,6 +31,8 @@ toplevel.decl=\
     import com.sun.tools.javac.util.JCDiagnostic.Warning;\n\
     import com.sun.tools.javac.util.JCDiagnostic.Note;\n\
     import com.sun.tools.javac.util.JCDiagnostic.Fragment;\n\
+    import com.sun.tools.javac.util.JCDiagnostic.InfoFragment;\n\
+    import com.sun.tools.javac.util.JCDiagnostic.HelpFragment;\n\
     \n\
     public class {2} '{'\n\
     {3}\n\

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
@@ -41,6 +41,7 @@ import com.sun.tools.javac.main.Option.PkgInfo;
 import com.sun.tools.javac.resources.CompilerProperties;
 import com.sun.tools.javac.resources.CompilerProperties.Errors;
 import com.sun.tools.javac.resources.CompilerProperties.Fragments;
+import com.sun.tools.javac.resources.CompilerProperties.Infos;
 import com.sun.tools.javac.resources.CompilerProperties.Warnings;
 import com.sun.tools.javac.tree.*;
 import com.sun.tools.javac.tree.JCTree.*;
@@ -549,7 +550,7 @@ public class Enter extends JCTree.Visitor {
 
     /** Complain about a duplicate class. */
     protected void duplicateClass(DiagnosticPosition pos, ClassSymbol c, ClassSymbol existingClass) {
-        log.error(pos, Errors.DuplicateClass(c.fullname), new Info(Fragments.InfoClassAlreadyDefined(existingClass.sourcefile.getName())));
+        log.error(pos, Errors.DuplicateClass(c.fullname), new Info(Infos.ClassAlreadyDefined(existingClass.sourcefile.getName())));
     }
 
     /** Class enter visitor method for type parameters.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -39,7 +39,9 @@ import com.sun.source.tree.LambdaExpressionTree.BodyKind;
 import com.sun.tools.javac.code.*;
 import com.sun.tools.javac.code.Scope.WriteableScope;
 import com.sun.tools.javac.code.Source.Feature;
+import com.sun.tools.javac.resources.CompilerProperties;
 import com.sun.tools.javac.resources.CompilerProperties.Errors;
+import com.sun.tools.javac.resources.CompilerProperties.Infos;
 import com.sun.tools.javac.resources.CompilerProperties.Warnings;
 import com.sun.tools.javac.tree.*;
 import com.sun.tools.javac.util.*;
@@ -1157,7 +1159,7 @@ public class Flow {
                             log.error(
                                     exit.tree.pos(),
                                     Errors.UnreportedExceptionNeedToCatchOrThrow(thrownExit.thrown),
-                                    new Info(Fragments.InfoFunctionDeclaredHere, List.of(new InfoPosition( log.currentSource(), thrownExit.declMethod.pos())))
+                                    new Info(Infos.FunctionDeclaredHere, List.of(new InfoPosition(log.currentSource(), thrownExit.declMethod.pos())))
                             );
                         }
                         log.error(exit.tree.pos(), Errors.UnreportedExceptionNeedToCatchOrThrow(thrownExit.thrown));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -43,6 +43,7 @@ import com.sun.tools.javac.jvm.*;
 import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.resources.CompilerProperties.Errors;
 import com.sun.tools.javac.resources.CompilerProperties.Fragments;
+import com.sun.tools.javac.resources.CompilerProperties.Helps;
 import com.sun.tools.javac.resources.CompilerProperties.Warnings;
 import com.sun.tools.javac.tree.*;
 import com.sun.tools.javac.tree.JCTree.*;
@@ -4071,7 +4072,7 @@ public class Resolve {
                                     typeargtypes, args(argtypes), //type parameters and arguments (if any)
                                     getLocationDiag(location, site)); //location kindname, type
                 if (suggestMember != null) {
-                    diag = diag.withHelp(new Help(Fragments.HelpSimilarSymbol(Kinds.kindName(suggestMember), suggestMember)));
+                    diag = diag.withHelp(new Help(Helps.SimilarSymbol(Kinds.kindName(suggestMember), suggestMember)));
                 }
 
                 return diag;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -40,6 +40,8 @@ import com.sun.tools.javac.parser.Tokens.*;
 import com.sun.tools.javac.parser.Tokens.Comment.CommentStyle;
 import com.sun.tools.javac.resources.CompilerProperties.Errors;
 import com.sun.tools.javac.resources.CompilerProperties.Fragments;
+import com.sun.tools.javac.resources.CompilerProperties.Helps;
+import com.sun.tools.javac.resources.CompilerProperties.Infos;
 import com.sun.tools.javac.resources.CompilerProperties.Warnings;
 import com.sun.tools.javac.tree.*;
 import com.sun.tools.javac.tree.JCTree.*;
@@ -48,7 +50,6 @@ import com.sun.tools.javac.util.JCDiagnostic.DiagnosticFlag;
 import com.sun.tools.javac.util.JCDiagnostic.Error;
 import com.sun.tools.javac.util.JCDiagnostic.Fragment;
 import com.sun.tools.javac.util.JCDiagnostic.RangeDiagnosticPosition;
-import com.sun.tools.javac.util.JCDiagnostic.SimpleDiagnosticPosition;
 import com.sun.tools.javac.util.List;
 
 import static com.sun.tools.javac.parser.Tokens.TokenKind.*;
@@ -584,7 +585,7 @@ public class JavacParser implements Parser {
                     token.pos,
                     Errors.AssertAsIdentifier,
                     new Help(
-                            Fragments.HelpRenameTheIdentifier,
+                            Helps.RenameTheIdentifier,
                             List.of(new SuggestedChange(
                                     log.currentSource(),
                                     new RangeDiagnosticPosition(token.pos, token.endPos),
@@ -686,8 +687,8 @@ public class JavacParser implements Parser {
                     log.error(DiagnosticFlag.SYNTAX,
                               token.pos,
                               Errors.IntNumberTooLarge(strval(prefix)),
-                              new Info(Fragments.InfoIntNumberRange), new Help(
-                                    Fragments.HelpUseLongIntegerLiteral,
+                              new Info(Infos.IntNumberRange), new Help(
+                                    Helps.UseLongIntegerLiteral,
                                     List.of(new SuggestedChange(
                                             log.currentSource(),
                                             new RangeDiagnosticPosition(token.pos, token.endPos),
@@ -699,7 +700,7 @@ public class JavacParser implements Parser {
                     log.error(DiagnosticFlag.SYNTAX,
                               token.pos,
                               Errors.IntNumberTooLarge(strval(prefix)),
-                              new Info(Fragments.InfoLongNumberRange));
+                              new Info(Infos.LongNumberRange));
                 }
             }
             break;
@@ -709,7 +710,7 @@ public class JavacParser implements Parser {
                     TypeTag.LONG,
                     Long.valueOf(Convert.string2long(strval(prefix), token.radix())));
             } catch (NumberFormatException ex) {
-                log.error(DiagnosticFlag.SYNTAX, token.pos, Errors.IntNumberTooLarge(strval(prefix)), new Info(Fragments.InfoLongNumberRange));
+                log.error(DiagnosticFlag.SYNTAX, token.pos, Errors.IntNumberTooLarge(strval(prefix)), new Info(Infos.LongNumberRange));
             }
             break;
         case FLOATLITERAL: {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3929,17 +3929,17 @@ compiler.err.enclosing.class.type.non.denotable=\
 # INFO
 ##########################################
 
-compiler.misc.info.function.declared.here=\
+compiler.info.function.declared.here=\
     function declared here
 
-compiler.misc.info.int.number.range=\
+compiler.info.int.number.range=\
     int literals can store values from -2147483648 through 2147483647, inclusive.
 
-compiler.misc.info.long.number.range=\
+compiler.info.long.number.range=\
     long literals can store values from -9223372036854775808 through 9223372036854775807, inclusive.
 
 # 0: string
-compiler.misc.info.class.already.defined=\
+compiler.info.class.already.defined=\
     class already defined in {0}
 
 
@@ -3947,12 +3947,12 @@ compiler.misc.info.class.already.defined=\
 # HELPS
 ##########################################
 
-compiler.misc.help.rename.the.identifier=\
+compiler.help.rename.the.identifier=\
     rename the identifier
 
-compiler.misc.help.use.long.integer.literal=\
+compiler.help.use.long.integer.literal=\
     use a long instead
 
 # 0: kind name, 1: symbol
-compiler.misc.help.similar.symbol=\
+compiler.help.similar.symbol=\
     a similarly named {0} exists: {1}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Help.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Help.java
@@ -1,17 +1,17 @@
 package com.sun.tools.javac.util;
 
-import com.sun.tools.javac.util.JCDiagnostic.Fragment;
+import com.sun.tools.javac.util.JCDiagnostic.HelpFragment;
 
 public record Help(
-        Fragment message,
+        HelpFragment message,
         List<SuggestedChange> suggestedChanges
 ) {
 
-    public Help(final Fragment message) {
+    public Help(final HelpFragment message) {
         this(message, List.nil());
     }
 
-    public Help(final Fragment message, final List<SuggestedChange> suggestedChanges) {
+    public Help(final HelpFragment message, final List<SuggestedChange> suggestedChanges) {
         this.message = message;
         this.suggestedChanges = suggestedChanges;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Info.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Info.java
@@ -1,12 +1,12 @@
 package com.sun.tools.javac.util;
 
-import com.sun.tools.javac.util.JCDiagnostic.Fragment;
+import com.sun.tools.javac.util.JCDiagnostic.InfoFragment;
 
 public record Info(
-        Fragment message,
+        InfoFragment message,
         List<InfoPosition> positions
 ) {
-    public Info(Fragment message) {
+    public Info(InfoFragment message) {
         this(message, List.nil());
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/JCDiagnostic.java
@@ -425,7 +425,11 @@ public class JCDiagnostic implements Diagnostic<JavaFileObject> {
         /** A warning. */
         WARNING("warn"),
         /** An error. */
-        ERROR("err");
+        ERROR("err"),
+        /** An info, used to provide context to errors */
+        INFO("info"),
+        /** A help, used to suggest changes */
+        HELP("help");
 
         final String key;
 
@@ -728,6 +732,18 @@ public class JCDiagnostic implements Diagnostic<JavaFileObject> {
     public static final class Fragment extends DiagnosticInfo {
         public Fragment(String prefix, String key, Object... args) {
             super(DiagnosticType.FRAGMENT, prefix, key, args);
+        }
+    }
+
+    public static final class InfoFragment extends DiagnosticInfo {
+        public InfoFragment(String prefix, String code, Object... args) {
+            super(INFO, prefix, code, args);
+        }
+    }
+
+    public static final class HelpFragment extends DiagnosticInfo {
+        public HelpFragment(String prefix, String code, Object... args) {
+            super(HELP, prefix, code, args);
         }
     }
 


### PR DESCRIPTION
Moves all `Fragments.InfoXYZ` to `Infos.XYZ` and `Fragments.HelpXYZ` to `Helps.XYZ`